### PR TITLE
Fix for having 2 dependency chains when resolving with bndtools

### DIFF
--- a/bbm-p2-repository/bbm-update-site/category.xml
+++ b/bbm-p2-repository/bbm-update-site/category.xml
@@ -3,19 +3,19 @@
    <description name="BBM Libraries" url="http://p2.babymotte.de/">
       BBM Libraries
    </description>
-   <bundle id="net.bbmsoft.fxtended" version="1.4.2" label="FXtended">
+   <bundle id="net.bbmsoft.fxtended" version="1.4.3" label="FXtended">
       <category name="fxtended"/>
    </bundle>
-   <bundle id="net.bbmsoft.fxtended-runtime" version="1.3.2" label="FXtended Runtime">
+   <bundle id="net.bbmsoft.fxtended-runtime" version="1.3.3" label="FXtended Runtime">
       <category name="fxtended"/>
    </bundle>
-   <bundle id="net.bbmsoft.fxml-inject" version="1.3.2" label="FXML Inject">
+   <bundle id="net.bbmsoft.fxml-inject" version="1.3.3" label="FXML Inject">
       <category name="fxtended"/>
    </bundle>
-   <bundle id="net.bbmsoft.osk-fx" version="1.2.3" label="OSK">
+   <bundle id="net.bbmsoft.osk-fx" version="1.2.4" label="OSK">
       <category name="osk"/>
    </bundle>
-   <bundle id="net.bbmsoft.bbm-utils" version="1.1.2">
+   <bundle id="net.bbmsoft.bbm-utils" version="1.1.3">
       <category name="bbm-utils"/>
    </bundle>
    <category-def name="fxtended" label="FXtended">

--- a/bbm-p2-repository/bbm-update-site/pom.xml
+++ b/bbm-p2-repository/bbm-update-site/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>net.bbmsoft</groupId>
 		<artifactId>bbm-p2-repository</artifactId>
-		<version>1.0.4</version>
+		<version>1.2.1</version>
 	</parent>
 
 	<packaging>eclipse-repository</packaging>
@@ -19,42 +19,41 @@
 		<dependency>
 			<groupId>net.bbmsoft</groupId>
 			<artifactId>fxtended</artifactId>
-			<version>1.4.2</version>
+			<version>1.4.3</version>
 			<classifier>no-fx-imports</classifier>
 		</dependency>
 
 		<dependency>
 			<groupId>net.bbmsoft</groupId>
 			<artifactId>fxtended-runtime</artifactId>
-			<version>1.3.2</version>
+			<version>1.3.3</version>
 			<classifier>no-fx-imports</classifier>
 		</dependency>
 
 		<dependency>
 			<groupId>net.bbmsoft</groupId>
 			<artifactId>fxml-inject</artifactId>
-			<version>1.3.2</version>
+			<version>1.3.3</version>
 			<classifier>no-fx-imports</classifier>
 		</dependency>
 
 		<dependency>
 			<groupId>net.bbmsoft</groupId>
 			<artifactId>osk-fx</artifactId>
-			<version>1.2.3</version>
+			<version>1.2.4</version>
 			<classifier>no-fx-imports</classifier>
 		</dependency>
 
 		<dependency>
 			<groupId>net.bbmsoft</groupId>
 			<artifactId>bbm-utils</artifactId>
-			<version>1.1.2</version>
+			<version>1.1.3</version>
 			<classifier>no-fx-imports</classifier>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.xtend</groupId>
 			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>2.11.0</version>
 		</dependency>
 
 	</dependencies>

--- a/bbm-p2-repository/pom.xml
+++ b/bbm-p2-repository/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>net.bbmsoft</groupId>
 		<artifactId>bbm-libs</artifactId>
-		<version>1.0.4</version>
+		<version>1.2.1</version>
 	</parent>
 	
 	<properties>

--- a/bbm-utils/pom.xml
+++ b/bbm-utils/pom.xml
@@ -5,13 +5,13 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>bbm-utils</artifactId>
-	<version>1.1.2</version>
+	<version>1.1.3</version>
 	<name>BBM Utils</name>
 
 	<parent>
 		<groupId>net.bbmsoft</groupId>
 		<artifactId>bbm-libs</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1</version>
 	</parent>
 
 	<dependencies>

--- a/fxml-inject/pom.xml
+++ b/fxml-inject/pom.xml
@@ -5,14 +5,14 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>fxml-inject</artifactId>
-	<version>1.3.2</version>
+	<version>1.3.3</version>
 	<name>FXML-Inject</name>
 	<description>A custom FXML Loader that allows dependency injection for object/node instantiation.</description>
 
 	<parent>
 		<groupId>net.bbmsoft</groupId>
 		<artifactId>bbm-libs</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1</version>
 	</parent>
 
 	<dependencies>

--- a/fxtended-runtime/pom.xml
+++ b/fxtended-runtime/pom.xml
@@ -5,14 +5,14 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>fxtended-runtime</artifactId>
-	<version>1.3.2</version>
+	<version>1.3.3</version>
 	<name>FXtended Runtime</name>
 	<description>A collection of utility and extension classes and active annotations for general purpose and JavaFX 8 programming in the Xtend programming language.</description>
 
 	<parent>
 		<groupId>net.bbmsoft</groupId>
 		<artifactId>bbm-libs</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1</version>
 	</parent>
 
 	<dependencies>

--- a/fxtended/pom.xml
+++ b/fxtended/pom.xml
@@ -5,14 +5,14 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>fxtended</artifactId>
-	<version>1.4.2</version>
+	<version>1.4.3</version>
 	<name>FXtended</name>
 	<description>A collection of utility and extension classes and active annotations for general purpose and JavaFX 8 programming in the Xtend programming language.</description>
 
 	<parent>
 		<groupId>net.bbmsoft</groupId>
 		<artifactId>bbm-libs</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1</version>
 	</parent>
 
 	<dependencies>

--- a/osk-fx/pom.xml
+++ b/osk-fx/pom.xml
@@ -5,14 +5,14 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>osk-fx</artifactId>
-	<version>1.2.3</version>
+	<version>1.2.4</version>
 
 	<name>OSK FX</name>
 
 	<parent>
 		<groupId>net.bbmsoft</groupId>
 		<artifactId>bbm-libs</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1</version>
 	</parent>
 
 	<dependencies>
@@ -20,13 +20,13 @@
 		<dependency>
 			<groupId>net.bbmsoft</groupId>
 			<artifactId>fxtended</artifactId>
-			<version>1.4.0</version>
+			<version>1.4.3</version>
 		</dependency>
 
 		<dependency>
 			<groupId>net.bbmsoft</groupId>
 			<artifactId>fxtended-runtime</artifactId>
-			<version>1.3.0</version>
+			<version>1.3.3</version>
 		</dependency>
 		
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,15 @@
 
 	<groupId>net.bbmsoft</groupId>
 	<artifactId>bbm-libs</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 	<name>BBM-Software Libraries parent project</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<xtend.version>2.11.0</xtend.version>
+		<xtend.version>2.12.0</xtend.version>
 		<jar.plugin.version>3.0.2</jar.plugin.version>
+                <guava.version>18.0</guava.version>
 	</properties>
 
 	<packaging>pom</packaging>
@@ -30,7 +31,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>15.0</version>
+				<version>${guava.version}</version>
 			</dependency>
 
 			<dependency>
@@ -85,8 +86,13 @@
 				<artifactId>org.eclipse.xtext.xbase.testing</artifactId>
 				<version>${xtend.version}</version>
 				<scope>test</scope>
+				<exclusions>
+				        <exclusion>
+                                                <groupId>org.eclipse.lsp4j</groupId>
+                                                <artifactId>*</artifactId>
+				        </exclusion>
+				</exclusions>
 			</dependency>
-
 		</dependencies>
 	</dependencyManagement>
 
@@ -118,11 +124,11 @@
 								</goals>
 							</execution>
 						</executions>
-						<configuration>
+						<!--configuration>
 							<instructions>
 								<Import-Package>!javafx.*,!com.sun.*,*</Import-Package>
 							</instructions>
-						</configuration>
+						</configuration-->
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
fxtended-1.4.2 depend on org.eclipse.xtext.xbase.testing-2.11.0 which depend on org.eclipse.xtext.testing-2.11.0 which depend on org.eclipse.lsp4j-0.1.2 which depend on org.eclipse.lsp4j.generator-0.1.2 which depend on org.eclipse.xtend.lib-2.10.0.

This resulted into 2 dependency chains for org.eclipse.xtend.lib.macro in version=2.10.0 and 2.11.0.

Fix is to move to xtend 2.12.0. Also set exclusion for org.eclipse.lsp4j.
Besides this, the bundles now import javafx and sun packages and also using guava in version 18.
All artefact versions were updated appropriate.